### PR TITLE
OT92-73-Metodo-reutilizable-Delete-privateAPI

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -2,7 +2,8 @@ import axios from 'axios';
 
 const config = {
     headers: {
-        Group: 01                //Aqui va el ID del equipo!!
+        Group: 92,
+        Authorization: null,
     }
 }
 
@@ -13,3 +14,18 @@ const Get = () => {
 }
 
 export default Get
+
+const queryDeleteById = async (section, id) => {
+    const url = `http://ongapi.alkemy.org/api/${section}/${id}`;
+    const configuration = getAuthorization();
+    /* Este metodo getAuthorization() fue desarrollado en el ticket 69
+    por Facundo Delavalle */
+    let res = await axios.delete(url, configuration);
+    try {
+        console.log(`Deleted succesfully`);
+        console.log(res.status);
+    } catch (error) {
+        console.log("Something went wrong: " + error)
+    }
+}
+export { queryDeleteById };


### PR DESCRIPTION
I made an HTTP request for DELETE purposes. Its params are "section" (users, activities, etc.) and "id". Both of them are used later in a template string for the endpoint URL.
I worked with Facundo Delavalle who did the "getAuthorization" method in a previous ticket in the epic. I explain this because the method is not defined in my function. This returns a header where the "Authorization" is "Bearer {token}" instead of being "null".
