### PR TITLE
OT-92-75 crear-método-reutilizable-post-endpoints-públicos

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import ToysCampaign from './Campaigns/Toys/ToysCampaign';
 import MembersForm from './Components/Members/MembersForm';
 import ProjectsForm from './Components/Projects/ProjectsForm';
 import ScreenDashboard from './Components/Backoffice/ScreenDashboard';
-import NewsDetail from './Components/News/Detail/Index';
+import NewsDetail from './Components/News/Detail';
 import Organization from './Components/Organization/Organization';
 import MembersCreateEdit from './Components/Members/MembersCreateEdit';
 import UpdateDataForm from './Components/Organization/UdpateDataForm';
@@ -26,7 +26,7 @@ function App() {
     <>
       <BrowserRouter>
         <Switch>
-          <Route path="/" exact component={} />
+          <Route path="/" exact  />
           <Route path="/activities/:id" component={ActivitiesDetail} />
           <Route path="/backoffice/create-slide" component={SlidesForm} />
           <Route path="/backoffice/home" component={HomeForm} />

--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -12,7 +12,8 @@ const Get = () => {
     .catch(err => console.log(err))
 }
 
-const publicPost = async (url, body) => {
+const publicPost = async (url, body) => {    //creamos un método POST para que pueda ser utilizado
+                                            //en toda la app
      try{
        const response = await axios({
            method: 'POST',

--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const config = {
     headers: {
-        Group: 01                //Aqui va el ID del equipo!!
+        Group: 92               //Aqui va el ID del equipo!!
     }
 }
 
@@ -12,4 +12,18 @@ const Get = () => {
     .catch(err => console.log(err))
 }
 
-export default Get
+const publicPost = async (url, body) => {
+     try{
+       const response = await axios({
+           method: 'POST',
+           url: url,
+           data: body
+       })
+       console.log(response)
+       return response
+     }catch (err){
+         console.log(err)
+     }
+}
+export default publicPost
+


### PR DESCRIPTION
- Created a method at "/publicApiService.js", which we will be able to use all around the app, to make POST requests to given endpoints.
- I tested it and it worked just fine, giving a 200 response. Below I leave a screenshot:

![peticion-post-publica](https://user-images.githubusercontent.com/80073511/140241618-9f3c9161-26a3-4fd4-8b3d-80a97b74366e.png)

