### PR TITLE
OT92-36-Crear-componente-de-formulario-de-contacto

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import HomeForm from './Components/Home/HomeForm';
 import NewsDisplay from './Components/News/NewsDisplay';
 import LoginForm from './Components/Auth/LoginForm';
 import About from './Components/About'
+import ContactForm from './Components/Contact/ContactForm';
 
 
 function App() {
@@ -28,7 +29,7 @@ function App() {
     <>
       <BrowserRouter>
         <Switch>
-          <Route path="/" exact />
+          <Route path="/" exact component={ContactForm}/>
           <Route path="/activities/:id" component={ActivitiesDetail} />
           <Route path="/backoffice/create-slide" component={SlidesForm} />
           <Route path="/backoffice/home" component={HomeForm} />

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,6 @@ import HomeForm from './Components/Home/HomeForm';
 import NewsDisplay from './Components/News/NewsDisplay';
 import LoginForm from './Components/Auth/LoginForm';
 import About from './Components/About'
-import ContactForm from './Components/Contact/ContactForm';
 
 
 function App() {
@@ -29,7 +28,7 @@ function App() {
     <>
       <BrowserRouter>
         <Switch>
-          <Route path="/" exact component={ContactForm}/>
+          <Route path="/" exact />
           <Route path="/activities/:id" component={ActivitiesDetail} />
           <Route path="/backoffice/create-slide" component={SlidesForm} />
           <Route path="/backoffice/home" component={HomeForm} />

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -5,37 +5,37 @@ import TextInput from '../Newsletter/TextInput';
 
 const ContactForm = () => {
     return (
-        <div className="form-container">
-            <h3>Contactanos</h3>
+        <>
             <Formik>
-                <Form>
+                <Form className="form-container">
+                    <h3>Contactanos</h3>
                     <TextInput 
-                        label=""
-                        name=""
-                        type=""
-                        placeholder=""
+                        label="Nombre y Apellido"
+                        name="name"
+                        type="text"
+                        placeholder="Juan Perez"
                     />
                     <TextInput 
-                        label=""
-                        name=""
-                        type=""
-                        placeholder=""
+                        label="Email"
+                        name="email"
+                        type="email"
+                        placeholder="juanperez@gmail.com"
                     />
                     <TextInput 
-                        label=""
-                        name=""
-                        type=""
-                        placeholder=""
+                        label="Telefono"
+                        name="phone"
+                        type="number"
+                        placeholder="12345678"
                     />
                     <TextInput 
-                        label=""
-                        name=""
-                        type=""
-                        placeholder=""
+                        label="Mensaje"
+                        name="message"
+                        type="text"
+                        placeholder="Envíanos tu consulta o mensaje."
                     />
                 </Form>
             </Formik>
-        </div>
+        </>
     )
 }
 

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -6,7 +6,31 @@ import TextInput from '../Newsletter/TextInput';
 const ContactForm = () => {
     return (
         <>
-            <Formik>
+            <Formik
+                initialValues={{
+                    name: '',
+                    email: '',
+                    phone: '',
+                    message: '',
+                }}
+                validationSchema={Yup.object({
+                    name: Yup.string()
+                        .required('Requerido'),
+                    email: Yup.string().email('Correo inválido')
+                        .required('Requerido'),
+                    phone: Yup.number()
+                        .min(8, "Debe tener como mínimo 8 caracteres")
+                        .required('Requerido'),
+                    message: Yup.string()
+                        .required('Requerido')
+                })}
+                onSubmit={(values, { setSubmitting }) => {
+                    setTimeout(() => {
+                        console.log(JSON.stringify(values, null, 2));
+                        setSubmitting(false)
+                    }, 400)
+                }}
+            >
                 <Form className="form-container">
                     <h3>Contactanos</h3>
                     <TextInput 

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -28,6 +28,7 @@ const ContactForm = () => {
                 onSubmit={(values, { setSubmitting }) => {
                     setTimeout(() => {
                         console.log(JSON.stringify(values, null, 2));
+                        //Aquí irá la función para enviar la información submiteada
                         setSubmitting(false)
                     }, 400)
                 }}

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -1,10 +1,13 @@
 import React from 'react'
+import { Formik, Form } from 'formik';
+import * as Yup from 'yup';
+import TextInput from '../Newsletter/TextInput';
 
 const ContactForm = () => {
     return (
         <div className="form-container">
             <h3>Contactanos</h3>
-            
+
         </div>
     )
 }

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const ContactForm = () => {
+    return (
+        <div className="form-container">
+            <h3>Contactanos</h3>
+            
+        </div>
+    )
+}
+
+export default ContactForm

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -7,7 +7,34 @@ const ContactForm = () => {
     return (
         <div className="form-container">
             <h3>Contactanos</h3>
-
+            <Formik>
+                <Form>
+                    <TextInput 
+                        label=""
+                        name=""
+                        type=""
+                        placeholder=""
+                    />
+                    <TextInput 
+                        label=""
+                        name=""
+                        type=""
+                        placeholder=""
+                    />
+                    <TextInput 
+                        label=""
+                        name=""
+                        type=""
+                        placeholder=""
+                    />
+                    <TextInput 
+                        label=""
+                        name=""
+                        type=""
+                        placeholder=""
+                    />
+                </Form>
+            </Formik>
         </div>
     )
 }

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -18,9 +18,10 @@ const ContactForm = () => {
                         .required('Requerido'),
                     email: Yup.string().email('Correo inválido')
                         .required('Requerido'),
-                    phone: Yup.number()
+                    phone: Yup.string()
+                        .matches(/^[0-9]+$/, "Solo se pueden ingresar números")
                         .min(8, "Debe tener como mínimo 8 caracteres")
-                        .required('Requerido'),
+                        .required('Requerido - Ingresar solo números'),
                     message: Yup.string()
                         .required('Requerido')
                 })}

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -57,6 +57,7 @@ const ContactForm = () => {
                         type="text"
                         placeholder="Envíanos tu consulta o mensaje."
                     />
+                    <button className="btn-submit-Crear-Editar-Members btn btn-success" type="submit">Enviar</button>
                 </Form>
             </Formik>
         </>

--- a/src/Components/FormStyles.css
+++ b/src/Components/FormStyles.css
@@ -114,3 +114,9 @@
     margin-top: 3%;
     cursor: pointer;
 }
+
+@media only screen and (max-width: 740px) {
+    .btn-submit-Crear-Editar-Members{
+        width: 25vw;
+    }
+}


### PR DESCRIPTION
I made the ContactForm component that consists of 4 fields (all required):
- The name field: only required
- The email field: required and with email format
- The phone field: required, having 8 digits or more, and only numbers.
- The message field: only required.
I created this in a new folder named "Contact". 
I use Formik, Yup, and a reusable component from a past ticket (Newsletter form) for the inputs and the error messages.

Evidence:
![Evidencia 36-1](https://user-images.githubusercontent.com/77683363/140635681-d62b00fd-3b2e-463f-92f1-c0943943d104.png)
![Evidencia 36-2](https://user-images.githubusercontent.com/77683363/140635683-2cec7083-53e3-4385-9427-3e6d52583765.png)
![Evidencia 36-3](https://user-images.githubusercontent.com/77683363/140635684-962a5d52-2bd9-4488-96bf-924e954a7f92.png)
![Evidencia 36-4](https://user-images.githubusercontent.com/77683363/140635685-929875e2-44c5-45e7-92e6-6c4bce6686ca.png)
